### PR TITLE
set ignorethrottling to True in ATLAS v3.10.1 easyconfigs

### DIFF
--- a/easybuild/easyconfigs/a/ATLAS/ATLAS-3.10.1-gompi-1.5.12-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/a/ATLAS/ATLAS-3.10.1-gompi-1.5.12-LAPACK-3.4.2.eb
@@ -28,4 +28,9 @@ full_lapack = True
 # fix for http://math-atlas.sourceforge.net/errata.html#sharedProbe
 configopts = "-Ss f77lib '-L$(EBROOTGCC)/lib64 -lgfortran'"
 
+# ignore check done by ATLAS for CPU throttling;
+# you should set this to False (or remove it)
+# and disable CPU throttling (requires root privileges) if you can
+ignorethrottling = True
+
 moduleclass = 'numlib'

--- a/easybuild/easyconfigs/a/ATLAS/ATLAS-3.10.1-gompi-1.5.12-no-OFED-LAPACK-3.4.2.eb
+++ b/easybuild/easyconfigs/a/ATLAS/ATLAS-3.10.1-gompi-1.5.12-no-OFED-LAPACK-3.4.2.eb
@@ -28,4 +28,9 @@ full_lapack = True
 # fix for http://math-atlas.sourceforge.net/errata.html#sharedProbe
 configopts = "-Ss f77lib '-L$(EBROOTGCC)/lib64 -lgfortran'"
 
+# ignore check done by ATLAS for CPU throttling;
+# you should set this to False (or remove it)
+# and disable CPU throttling (requires root privileges) if you can
+ignorethrottling = True
+
 moduleclass = 'numlib'


### PR DESCRIPTION
This will be handled in the ATLAS easyblock, such that ATLAS v3.10.1 can be built even when throttling is enabled.
