### PR TITLE
enhance PSI patch to resolve more errors w.r.t. memcpy not being in scope

### DIFF
--- a/easybuild/easyconfigs/p/PSI/PSI-4.0b4-mpi.patch
+++ b/easybuild/easyconfigs/p/PSI/PSI-4.0b4-mpi.patch
@@ -1,3 +1,12 @@
+--- psi4.0b4/src/lib/libparallel/mpi_wrapper.h.orig 2013-10-02 14:24:01.948223891 +0200
++++ psi4.0b4/src/lib/libparallel/mpi_wrapper.h  2013-10-02 14:31:02.282094030 +0200
+@@ -1,5 +1,6 @@
+ #if defined(HAVE_MPI)
+ 
++#include <cstring>
+ #include <mpi.h>
+ 
+ namespace psi {
 --- psi4.0b4/src/lib/libmints/wavefunction.h.orig	2013-05-07 18:35:18.813690853 +0200
 +++ psi4.0b4/src/lib/libmints/wavefunction.h	2013-05-07 18:35:43.113781216 +0200
 @@ -6,7 +6,8 @@


### PR DESCRIPTION
Without this, I was (sometimes?) running into problems like:

```
/tmp/easybuild_build/PSI/4.0b4/ictce-4.1.13/psi4.0b4/src/lib/libparallel/mpi_wrapper.h(80): error: the global scope has no "memcpy"
          ::memcpy(static_cast<void*>(data), static_cast<void*>(receive_buffer), sizeof(double)*nelem);
            ^

/tmp/easybuild_build/PSI/4.0b4/ictce-4.1.13/psi4.0b4/src/lib/libparallel/mpi_wrapper.h(104): error: the global scope has no "memcpy"
      SUMMEMBER(double, MPI_DOUBLE)
      ^

/tmp/easybuild_build/PSI/4.0b4/ictce-4.1.13/psi4.0b4/src/lib/libparallel/mpi_wrapper.h(105): error: the global scope has no "memcpy"
      SUMMEMBER(unsigned int, MPI_INT)
```
