### PR TITLE
align PSI easyconfigs, correct filename of -mt PSI goalf easyconfig, add mpi PSI goalf easyconfig

### DIFF
--- a/easybuild/easyconfigs/n/NWChem/NWChem-6.1.1-ictce-4.1.13-2012-06-27-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/n/NWChem/NWChem-6.1.1-ictce-4.1.13-2012-06-27-Python-2.7.3.eb
@@ -25,7 +25,4 @@ dependencies = [(python, pyver)]
 
 modules = 'all python'
 
-# 12/43 tests fail (exit code 1), so needs to bump up the max fail ratio
-max_fail_ratio = 0.5
-
 moduleclass = 'chem'

--- a/easybuild/easyconfigs/p/PSI/PSI-4.0b5-goalf-1.5.12-no-OFED-mt.eb
+++ b/easybuild/easyconfigs/p/PSI/PSI-4.0b5-goalf-1.5.12-no-OFED-mt.eb
@@ -7,7 +7,7 @@ description = """PSI4 is an open-source suite of ab initio quantum chemistry pro
 efficient, high-accuracy simulations of a variety of molecular properties. We can routinely perform
 computations with more than 2500 basis functions running serially or in parallel."""
 
-toolchain = {'name': 'ictce', 'version': '5.5.0'}
+toolchain = {'name': 'goalf', 'version': '1.5.12-no-OFED'}
 # not using MPI results in a build relying on multithreaded BLAS solely
 toolchainopts = {'usempi': False}
 

--- a/easybuild/easyconfigs/p/PSI/PSI-4.0b5-goalf-1.5.12-no-OFED.eb
+++ b/easybuild/easyconfigs/p/PSI/PSI-4.0b5-goalf-1.5.12-no-OFED.eb
@@ -7,13 +7,13 @@ efficient, high-accuracy simulations of a variety of molecular properties. We ca
 computations with more than 2500 basis functions running serially or in parallel."""
 
 toolchain = {'name': 'goalf', 'version': '1.5.12-no-OFED'}
-# not using MPI results in a build relying on multithreaded BLAS solely
-toolchainopts = {'usempi': False}
+toolchainopts = {'usempi': True}
 
 source_urls = ['http://download.sourceforge.net/psicode/']
 sources = ['%(namelower)s%(version)s.tar.gz']
 
 patches = [
+    'PSI-4.0b5-mpi-memcpy.patch',
     'PSI-4.0b5-failed-test.patch', # The test works but it segfaults on exit
     'PSI-4.0b5-thread-pool.patch',
     'PSI-4.0b5-new-plugin.patch',

--- a/easybuild/easyconfigs/p/PSI/PSI-4.0b5-mpi-memcpy.patch
+++ b/easybuild/easyconfigs/p/PSI/PSI-4.0b5-mpi-memcpy.patch
@@ -53,7 +53,7 @@ diff -ur psi4.0b5.orig/src/lib/libparallel/mpi_wrapper.h psi4.0b5/src/lib/libpar
      }
 --- psi4.0b5/src/lib/libmints/wavefunction.h.orig    2013-10-10 21:41:48.177679312 +0200
 +++ psi4.0b5/src/lib/libmints/wavefunction.h   2013-10-10 21:41:37.884807311 +0200
-@@ -28,6 +28,7 @@
+@@ -28,7 +28,8 @@
  
  #include "typedefs.h"
  #include <libparallel/parallel.h>

--- a/easybuild/easyconfigs/p/PSI/PSI-4.0b5-mpi-memcpy.patch
+++ b/easybuild/easyconfigs/p/PSI/PSI-4.0b5-mpi-memcpy.patch
@@ -51,3 +51,13 @@ diff -ur psi4.0b5.orig/src/lib/libparallel/mpi_wrapper.h psi4.0b5/src/lib/libpar
              delete[] receive_buffer; \
          } \
      }
+--- psi4.0b5/src/lib/libmints/wavefunction.h.orig    2013-10-10 21:41:48.177679312 +0200
++++ psi4.0b5/src/lib/libmints/wavefunction.h   2013-10-10 21:41:37.884807311 +0200
+@@ -28,7 +28,6 @@
+ 
+ #include "typedefs.h"
+ #include <libparallel/parallel.h>
++#include <liboptions/liboptions.h>
+ 
+ #define MAX_IOFF 30000
+ extern size_t ioff[MAX_IOFF];

--- a/easybuild/easyconfigs/p/PSI/PSI-4.0b5-mpi-memcpy.patch
+++ b/easybuild/easyconfigs/p/PSI/PSI-4.0b5-mpi-memcpy.patch
@@ -53,7 +53,7 @@ diff -ur psi4.0b5.orig/src/lib/libparallel/mpi_wrapper.h psi4.0b5/src/lib/libpar
      }
 --- psi4.0b5/src/lib/libmints/wavefunction.h.orig    2013-10-10 21:41:48.177679312 +0200
 +++ psi4.0b5/src/lib/libmints/wavefunction.h   2013-10-10 21:41:37.884807311 +0200
-@@ -28,7 +28,6 @@
+@@ -28,6 +28,7 @@
  
  #include "typedefs.h"
  #include <libparallel/parallel.h>


### PR DESCRIPTION
fix goalf easyconfig filename, and added the MPI equivalent while at it

also fixed order of patch files for consistency across easyconfigs that only differ in toolchain

still testing this, but looks OK to me...
