### PR TITLE
fix icc/ifort/impi/imkl 2017.* versions, add intel/2017.00 definition + HPL 2.2

### DIFF
--- a/easybuild/easyconfigs/h/HPL/HPL-2.2-intel-2017.00.eb
+++ b/easybuild/easyconfigs/h/HPL/HPL-2.2-intel-2017.00.eb
@@ -1,0 +1,18 @@
+name = 'HPL'
+version = '2.2'
+
+homepage = 'http://www.netlib.org/benchmark/hpl/'
+description = """HPL is a software package that solves a (random) dense linear system in double precision (64 bits) arithmetic 
+ on distributed-memory computers. It can thus be regarded as a portable as well as freely available implementation of the 
+ High Performance Computing Linpack Benchmark."""
+
+toolchain = {'name': 'intel', 'version': '2017.00'}
+toolchainopts = {'usempi': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.netlib.org/benchmark/%(namelower)s']
+
+# fix Make dependencies, so parallel build also works
+patches = ['HPL_parallel-make.patch']
+
+moduleclass = 'tools'

--- a/easybuild/easyconfigs/i/icc/icc-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/icc/icc-2017.0.098-GCC-5.4.0-2.26.eb
@@ -1,16 +1,16 @@
 # This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
 
-name = 'ifort'
-version = '2017.0.35'
+name = 'icc'
+version = '2017.0.098'
 
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran.tgz']
+sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp.tgz']
 
-checksums = ['8787795951fe10f90ce7dcdcec1b9341']
+checksums = ['c8a2fdb1501fbc93bfaad93195677d86']
 
 gccver = '5.4.0'
 binutilsver = '2.26'
@@ -24,7 +24,7 @@ dependencies = [
 # list of regex for components to install
 # full list of components can be obtained from pset/mediaconfig.xml in unpacked sources
 # cfr. https://software.intel.com/en-us/articles/intel-composer-xe-2015-silent-installation-guide
-components = ['intel-comp', 'intel-fcomp', 'intel-ifort', 'intel-openmp', 'intel-ipsf?_']
+components = ['intel-comp', 'intel-ccomp', 'intel-icc', 'intel-openmp', 'intel-ipsc?_']
 
 dontcreateinstalldir = 'True'
 

--- a/easybuild/easyconfigs/i/iccifort/iccifort-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iccifort/iccifort-2017.0.098-GCC-5.4.0-2.26.eb
@@ -2,7 +2,7 @@
 easyblock = "Toolchain"
 
 name = 'iccifort'
-version = '2017.0.35'
+version = '2017.0.098'
 versionsuffix = '-GCC-5.4.0-2.26'
 
 homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'

--- a/easybuild/easyconfigs/i/ifort/ifort-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/ifort/ifort-2017.0.098-GCC-5.4.0-2.26.eb
@@ -1,16 +1,16 @@
 # This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
 
-name = 'icc'
-version = '2017.0.35'
+name = 'ifort'
+version = '2017.0.098'
 
 homepage = 'http://software.intel.com/en-us/intel-compilers/'
 description = "C and C++ compiler from Intel"
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp.tgz']
+sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran.tgz']
 
-checksums = ['c8a2fdb1501fbc93bfaad93195677d86']
+checksums = ['8787795951fe10f90ce7dcdcec1b9341']
 
 gccver = '5.4.0'
 binutilsver = '2.26'
@@ -24,7 +24,7 @@ dependencies = [
 # list of regex for components to install
 # full list of components can be obtained from pset/mediaconfig.xml in unpacked sources
 # cfr. https://software.intel.com/en-us/articles/intel-composer-xe-2015-silent-installation-guide
-components = ['intel-comp', 'intel-ccomp', 'intel-icc', 'intel-openmp', 'intel-ipsc?_']
+components = ['intel-comp', 'intel-fcomp', 'intel-ifort', 'intel-openmp', 'intel-ipsf?_']
 
 dontcreateinstalldir = 'True'
 

--- a/easybuild/easyconfigs/i/iimpi/iimpi-2017.00-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/iimpi/iimpi-2017.00-GCC-5.4.0-2.26.eb
@@ -10,11 +10,11 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
-compver = '2017.0.35'
+compver = '2017.0.098'
 dependencies = [
     ('icc', compver, versionsuffix),
     ('ifort', compver, versionsuffix),
-    ('impi', '2017.0.98', '', ('iccifort', '%s%s' % (compver, versionsuffix))),
+    ('impi', '2017.0.098', '', ('iccifort', '%s%s' % (compver, versionsuffix))),
 ]
 
 moduleclass = 'toolchain'

--- a/easybuild/easyconfigs/i/imkl/imkl-2017.0.098-iimpi-2017.00-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/imkl/imkl-2017.0.098-iimpi-2017.00-GCC-5.4.0-2.26.eb
@@ -1,7 +1,7 @@
 # This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
 
 name = 'imkl'
-version = '2017.0.98'
+version = '2017.0.098'
 
 homepage = 'http://software.intel.com/en-us/intel-mkl/'
 description = """Intel Math Kernel Library is a library of highly optimized,

--- a/easybuild/easyconfigs/i/impi/impi-2017.0.098-iccifort-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2017.0.098-iccifort-2017.0.098-GCC-5.4.0-2.26.eb
@@ -1,14 +1,14 @@
 # This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
 
 name = 'impi'
-version = '2017.0.98'
+version = '2017.0.098'
 
 homepage = 'http://software.intel.com/en-us/intel-mpi-library/'
 description = """The Intel(R) MPI Library for Linux* OS is a multi-fabric message
  passing library based on ANL MPICH2 and OSU MVAPICH2. The Intel MPI Library for
  Linux OS implements the Message Passing Interface, version 2 (MPI-2) specification."""
 
-toolchain = {'name': 'iccifort', 'version': '2017.0.35-GCC-5.4.0-2.26'}
+toolchain = {'name': 'iccifort', 'version': '2017.0.098-GCC-5.4.0-2.26'}
 
 sources = ['l_mpi_p_%(version)s.tgz']
 

--- a/easybuild/easyconfigs/i/impi/impi-2017.0.098-iccifort-2017.0.098-GCC-5.4.0-2.26.eb
+++ b/easybuild/easyconfigs/i/impi/impi-2017.0.098-iccifort-2017.0.098-GCC-5.4.0-2.26.eb
@@ -10,7 +10,7 @@ description = """The Intel(R) MPI Library for Linux* OS is a multi-fabric messag
 
 toolchain = {'name': 'iccifort', 'version': '2017.0.098-GCC-5.4.0-2.26'}
 
-sources = ['l_mpi_p_%(version)s.tgz']
+sources = ['l_mpi_%(version)s.tgz']
 
 checksums = ['fc123875773816b7084a91e419d54d20']
 

--- a/easybuild/easyconfigs/i/intel/intel-2017.00.eb
+++ b/easybuild/easyconfigs/i/intel/intel-2017.00.eb
@@ -1,0 +1,24 @@
+easyblock = 'Toolchain'
+
+name = 'intel'
+version = '2017.00'
+
+homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and Fortran compilers, Intel MPI & Intel MKL."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+compver = '2017.0.098'
+gccver = '5.4.0'
+binutilsver = '2.26'
+gccsuff = '-GCC-%s-%s' % (gccver, binutilsver)
+dependencies = [
+    ('GCCcore', gccver),
+    ('binutils', binutilsver, '-GCCcore-%s' % gccver),
+    ('icc', compver, gccsuff),
+    ('ifort', compver, gccsuff),
+    ('impi', '2017.0.098', '', ('iccifort', '%s%s' % (compver, gccsuff))),
+    ('imkl', '2017.0.098', '', ('iimpi', version + gccsuff)),
+]
+
+moduleclass = 'toolchain'


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyconfigs/pull/3543

@wpoely86 `2017.0.098` makes more sense as version for `icc`/`ifort`? not sure where you got the `.35`...

```
$ icc -V
Intel(R) C Intel(R) 64 Compiler for applications running on Intel(R) 64, Version 17.0.0.098 Build 20160721
Copyright (C) 1985-2016 Intel Corporation.  All rights reserved.
```